### PR TITLE
Allow test classes to use test custom attributes

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CommandBuilder.cs
@@ -115,6 +115,12 @@ namespace NUnit.Framework.Internal.Execution
             foreach (ICommandWrapper decorator in test.Method.GetCustomAttributes<IWrapSetUpTearDown>(true))
                 command = decorator.Wrap(command);
 
+            foreach (var attribute in test.Method.MethodInfo.DeclaringType.GetCustomAttributes(typeof(IWrapSetUpTearDown), true))
+            {
+                var wrapper = (ICommandWrapper)attribute;
+                command = wrapper.Wrap(command);
+            }
+
             // Add command to set up context using attributes that implement IApplyToContext
             IApplyToContext[] changes = test.Method.GetCustomAttributes<IApplyToContext>(true);
             if (changes.Length > 0)

--- a/src/NUnitFramework/tests/Attributes/TestClassWrapperTest.cs
+++ b/src/NUnitFramework/tests/Attributes/TestClassWrapperTest.cs
@@ -1,0 +1,34 @@
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Commands;
+
+namespace NUnit.Framework.Tests.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false)]
+    class RetryClassAttribute : PropertyAttribute, IWrapSetUpTearDown
+    {
+        private readonly int _count;
+
+        public RetryClassAttribute(int count) : base(count)
+        {
+            _count = count;
+        }
+
+        public TestCommand Wrap(TestCommand command)
+        {
+            return new RetryAttribute.RetryCommand(command, _count);
+        }
+    }
+
+    [RetryClass(3)]
+    class TestClassWrapperTest
+	{
+		private int x = 0;
+
+		[Test]
+		public void TestMethod()
+		{
+		    Assert.AreEqual(x++, 2);
+		}
+    }
+}

--- a/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests-3.5.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Attributes\TestCaseSourceTests.cs" />
     <Compile Include="Attributes\TestDummy.cs" />
     <Compile Include="Attributes\TestExpectedResult.cs" />
+    <Compile Include="Attributes\TestClassWrapperTest.cs" />
     <Compile Include="TestParametersTests.cs" />
     <Compile Include="TestUtilities\AsyncTestDelegates.cs" />
     <Compile Include="Attributes\TestFixtureAttributeTests.cs" />


### PR DESCRIPTION
@chris-smith-zocdoc @Zocdoc/pinky @colin-hanson-zocdoc
This PR has the necessary changes in the ```CommandBuilder```class to allow test classes to use test attributes. **These changes work for all .NET frameworks but not .NET STD.** That is why I didn't merge yet.

@chris-smith-zocdoc suggest us to annotate for now individually all flaky tests instead of using per class level. My **RetryClass** attribute has the advantage to retry on exceptions as well. See this [line](https://github.com/nunit/nunit/compare/master...Zocdoc:mvs-allow-test-classes-to-use-test-custom-attributes?expand=1#diff-c34491d8bac07c34d352e74c52134f45R43).

I suggest you guys to either annotate test individually with the old retry attribute, or to just copy my new RetryClass attribute and use it in the test level. Let me know if you have any qyestions 